### PR TITLE
fix unbound variable if CLOUDFLARE_API_TOKEN is not defined

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -355,7 +355,7 @@ create_secret "$CONTEXT" "$NAMESPACE_BACKSTAGE" "pg-secret" "--from-literal=pass
 create_secret "$CONTEXT" "$NAMESPACE_MONITORING" "grafana-admin" "--from-literal=admin-user=admin --from-literal=admin-password=$ADMIN_PASSWORD --from-literal=ldap-toml="
 
 
-if [ -n "${CLOUDFLARE_API_TOKEN}" ]; then
+if [ -n "${CLOUDFLARE_API_TOKEN-}" ]; then
   # Cloudflare API Token Secret for ExternalDNS if CLOUDFLARE_API_TOKEN is provided
   create_secret "$CONTEXT" "$NAMESPACE_EXTERNALDNS" "cloudflare" "--from-literal=cloudflare_api_token=$CLOUDFLARE_API_TOKEN"
   # Cloudflare API Token Secret for Cert-Manager DNS01 Challenge if CLOUDFLARE_API_TOKEN is provided


### PR DESCRIPTION
Fixes 'unbound variable' if CLOUDFLARE_API_TOKEN is not defined

```
./scripts/install.sh kind-kuberise onprem https://github.com/bastiaanb/kuberise.io.git 
...
secret/grafana-admin created
./scripts/install.sh: line 358: CLOUDFLARE_API_TOKEN: unbound variable
```